### PR TITLE
Include response object in the exception.

### DIFF
--- a/lib/echonest-ruby-api/base.rb
+++ b/lib/echonest-ruby-api/base.rb
@@ -55,12 +55,15 @@ module Echonest
       options.each do |key, value|
         query_string << "#{ key }=#{ value }&"
       end
-      #puts "#{ Base.base_uri }#{ endpoint }?api_key=#{ @api_key }&format=json&#{ query_string }"
       response = HTTParty.get(URI.escape("#{ Base.base_uri }#{ endpoint }?api_key=#{ @api_key }&format=json&#{ query_string }"))
       json = MultiJson.load(response.body, symbolize_keys: true)
       response_code = json[:response][:status][:code]
 
-      response_code.eql?(0) ? json[:response] : raise(Echonest::Error.new(response_code), "Error code #{ response_code }")
+      if response_code.eql?(0)
+        json[:response]
+      else
+        raise Echonest::Error.new(response_code, response), "Error code #{ response_code }"
+      end
     end
 
     # Cross-platform way of finding an executable in the $PATH.

--- a/lib/echonest-ruby-api/error.rb
+++ b/lib/echonest-ruby-api/error.rb
@@ -1,7 +1,9 @@
 module Echonest
 
   class Error < Exception
-    ERRORS = { '-1' => 'Unknown Error', 
+    attr_reader :error_code, :response
+
+    ERRORS = { '-1' => 'Unknown Error',
                '0' => 'Success',
                '1' => 'Invalid/Missing API Key',
                '2' => 'This API key is not allowed to call that method',
@@ -11,15 +13,21 @@ module Echonest
                '6' => 'Missing echoprint-codegen binary on $PATH'
              }
 
-
-    # Create a new Echonest::Error object
-    def initialize(error_code)
+    def initialize(error_code, response = nil)
       @error_code = error_code
+      @response = response
     end
 
-    
     def description
       ERRORS[@error_code.to_s]
+    end
+
+    def details
+      if error_code == 3
+        # Returns a hash similar to {"remaining"=>0, "limit"=>20, "used"=>29}.
+        Hash[response.headers.select{|k,v| k =~ /x-ratelimit/}.
+          map{|k,v| [k.sub('x-ratelimit-', ''), v.first.to_i] }]
+      end
     end
 
   end


### PR DESCRIPTION
Also provide details for rate limit errors.

Having the full response object is very useful during debugging.
